### PR TITLE
Add event_port input to enable Firebird RemoteAuxPort (events support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ echo 'SELECT * FROM rdb$database;' | \
 `port`
 > Optional port published in the host for connecting to the database. Default 3050.
 
+`event_port`
+> Optional port for Firebird database events (`RemoteAuxPort`). If set, configures `RemoteAuxPort` in `firebird.conf` and publishes the port on the host. This is required when using Firebird event listeners from outside the container.
+
 `firebird_database`
 > Optional name for creating a database with the container
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Port published in the host for connecting to the database. Default: 3050.'
     required: false
     default: '3050'
+  event_port:
+    description: 'Optional port for Firebird events (RemoteAuxPort). If set, configures RemoteAuxPort in firebird.conf and publishes the port. Default: empty (disabled).'
+    required: false
+    default: ''
   firebird_database:
     description: 'Optional name for creating a database inside the container'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,10 +77,17 @@ if [ -n "${INPUT_VOLUMES:-}" ]; then
     IFS="${OLD_IFS}"
 fi
 
-echo "# Creating the FirebirdSQL Container: docker run --detach --name ${INPUT_CONTAINER_NAME:-firebirdsql} --publish ${INPUT_PORT:-3050}:3050 ${env_list} ${volumes_arg} firebirdsql/firebird:${INPUT_VERSION:-latest}"
+event_port_arg=''
+if [ -n "${INPUT_EVENT_PORT:-}" ]; then
+    printf '# Publishing event port (RemoteAuxPort): %s\n' "${INPUT_EVENT_PORT}"
+    env_list="${env_list} --env FIREBIRD_CONF_RemoteAuxPort=${INPUT_EVENT_PORT}"
+    event_port_arg="--publish ${INPUT_EVENT_PORT}:${INPUT_EVENT_PORT}"
+fi
+
+echo "# Creating the FirebirdSQL Container: docker run --detach --name ${INPUT_CONTAINER_NAME:-firebirdsql} --publish ${INPUT_PORT:-3050}:3050 ${env_list} ${event_port_arg} ${volumes_arg} firebirdsql/firebird:${INPUT_VERSION:-latest}"
 
 # shellcheck disable=SC2086
-if ! docker run --detach --name "${INPUT_CONTAINER_NAME:-firebirdsql}" --publish "${INPUT_PORT:-3050}:3050" ${network_arg} ${env_list} ${volumes_arg} "firebirdsql/firebird:${INPUT_VERSION:-latest}" ; then
+if ! docker run --detach --name "${INPUT_CONTAINER_NAME:-firebirdsql}" --publish "${INPUT_PORT:-3050}:3050" ${network_arg} ${env_list} ${event_port_arg} ${volumes_arg} "firebirdsql/firebird:${INPUT_VERSION:-latest}" ; then
     echo "## Failed to create the FirebirdSQL container! ##"
     exit 11
 fi


### PR DESCRIPTION
Firebird uses a secondary auxiliary port (`RemoteAuxPort`) for database event notifications. Without a fixed, published port, event listeners from outside the container cannot function.

## Changes

- **`action.yml`**: New optional `event_port` input (default: empty/disabled)
- **`entrypoint.sh`**: When `event_port` is set, injects `FIREBIRD_CONF_RemoteAuxPort=<port>` into the container and adds `--publish <port>:<port>` to the `docker run` invocation
- **`README.md`**: Documents the new parameter

## Example

```yaml
- uses: juarezr/firebirdsql-github-action@v2
  with:
    version: 'latest'
    firebird_database: 'my_database.fdb'
    firebird_root_password: 'masterkey'
    event_port: '3051'
```

This pins `RemoteAuxPort` to `3051` in `firebird.conf` and publishes it on the host, allowing event listeners to connect reliably.