### PR TITLE
docs+runtime: warn against mounting volumes under $GITHUB_WORKSPACE

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,29 @@ echo 'SELECT * FROM rdb$database;' | \
 > E.g.: `/tmp/firebird:/var/lib/firebird/data`.<br/>
 > This allows accessing database files directly from the host filesystem.
 
+> [!WARNING]
+> **Do not mount a path inside `${{ github.workspace }}` as a volume.**
+> When `actions/checkout` runs after this action (the default order in most workflows), it deletes and recreates the
+> workspace directory (`clean: true` is the default). This removes the host-side mount point, causing the Firebird
+> container to lose its data directory and breaking any tests that rely on mapped database files.
+>
+> Use `${{ runner.temp }}` instead – it persists for the entire job without being touched by checkout:
+>
+> ```yaml
+> volumes: '${{ runner.temp }}/firebird-data:/var/lib/firebird/data'
+> ```
+>
+> If you need tests to access the database files from the runner, pass the same directory to your test command:
+>
+> ```yaml
+> - uses: juarezr/firebirdsql-github-action@v2
+>   with:
+>     volumes: '${{ runner.temp }}/firebird-data:/var/lib/firebird/data'
+> - uses: actions/checkout@v4
+> - name: Run tests
+>   run: ./gradlew test -Ptest.db.mapped=${{ runner.temp }}/firebird-data
+> ```
+
 ### Deprecated v1 parameters
 
 `enable_legacy_client_auth`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,6 +71,14 @@ if [ -n "${INPUT_VOLUMES:-}" ]; then
         vol=$(printf '%s' "${vol}" | tr -d '\r')
         if [ -n "${vol}" ]; then
             printf '# Mounting volume: %s\n' "${vol}"
+            host_path="${vol%%:*}"
+            if [ -n "${GITHUB_WORKSPACE:-}" ] && \
+               case "${host_path}" in "${GITHUB_WORKSPACE}/"*) true ;; *) false ;; esac; then
+                echo "## WARNING: Volume host path '${host_path}' is inside \$GITHUB_WORKSPACE."
+                echo "## WARNING: If actions/checkout runs after this step (default), it will delete"
+                echo "## WARNING: the workspace directory (clean: true), breaking the volume mount."
+                echo "## WARNING: Use \${{ runner.temp }} instead to avoid this problem."
+            fi
             volumes_arg="${volumes_arg} --volume ${vol}"
         fi
     done


### PR DESCRIPTION
Mounting a volume host-path under `${{ github.workspace }}` breaks silently: `actions/checkout` (default `clean: true`) runs *after* this action in the typical workflow order and wipes the workspace, destroying the mount point while the Firebird container keeps running against a now-missing directory. This was the root cause of mapped-filesystem test failures observed in the Jaybird CI.

## Changes

- **README.md** — added a `[!WARNING]` callout under the `volumes` parameter:
  - Explains the checkout-order hazard
  - Recommends `${{ runner.temp }}` (job-scoped, never touched by checkout) as the correct host path
  - Includes a ready-to-use workflow snippet:

    ```yaml
    - uses: juarezr/firebirdsql-github-action@v2
      with:
        volumes: '${{ runner.temp }}/firebird-data:/var/lib/firebird/data'
    - uses: actions/checkout@v4
    - name: Run tests
      run: ./gradlew test -Ptest.db.mapped=${{ runner.temp }}/firebird-data
    ```

- **entrypoint.sh** — non-fatal runtime warning when a volume host-path begins with `$GITHUB_WORKSPACE/` (slash-bounded to avoid false-positives on sibling directories):

    ```
    ## WARNING: Volume host path '...' is inside $GITHUB_WORKSPACE.
    ## WARNING: If actions/checkout runs after this step (default), it will delete
    ## WARNING: the workspace directory (clean: true), breaking the volume mount.
    ## WARNING: Use ${{ runner.temp }} instead to avoid this problem.
    ```